### PR TITLE
Update the role description

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -14,7 +14,7 @@ textdomain="control"
         <label>Text Mode</label>
       </headless_role>
       <headless_role_description>
-        <label>• X server without GNOME</label>
+        <label>• Contains X server but no GNOME Desktop</label>
       </headless_role_description>
     </texts>
 

--- a/package/system-role-text-mode.changes
+++ b/package/system-role-text-mode.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 27 07:31:12 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Update the role description (bsc#1157329)
+- 15.2.0
+
+-------------------------------------------------------------------
 Wed Mar 13 09:36:39 UTC 2019 - jreidinger <jreidinger@suse.com>
 
 - enable role for SLES BCL (bsc#1128898)

--- a/package/system-role-text-mode.spec
+++ b/package/system-role-text-mode.spec
@@ -36,7 +36,7 @@ BuildRequires:  yast2-installation-control >= 4.0.4
 
 Url:            https://github.com/yast/system-role-text-mode
 AutoReqProv:    off
-Version:        15.1.4
+Version:        15.2.0
 Release:        0
 Summary:        Text Mode role definition
 License:        MIT


### PR DESCRIPTION
## Problem

The _X server without GNOME_ description is a bit misleading because

> So the X is installed, but there is no XDM/GDM/... running, text console only.
> 
> The label and the description are actually correct. It's really "Text mode" and "X server without > GNOME", but together it's quite confusing...  — @lslezak in [bsc#1157329-comment#2](https://bugzilla.suse.com/show_bug.cgi?id=1157329#c2)

Trello card: https://trello.com/c/JGjKNVlp

## Solution

Fix the description using the suggestion from [bsc#1157329-comment#4](https://bugzilla.suse.com/show_bug.cgi?id=1157329#c4)

> Contains X server but no GNOME Desktop

## :memo: Note

I found that role was formerly known as `system-role-server-headless` but it was adapted to the current `system-role-text-mode` not only changing the name but also adding the `x11` pattern. However, there is no info about why. See https://github.com/yast/system-role-text-mode/pull/1 
